### PR TITLE
Comment out github user in FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: bitcynth
+github: # bitcynth
 patreon: cynthiare
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
As otherwise sponsor button shows an angry message:

![Some errors were encountered when parsing the FUNDING.yml file: Some users provided are not enrolled in GitHub Sponsors. Apply to the beta.](https://elixi.re/i/i13q33oz.png)